### PR TITLE
Added javafx-media; Removed javafx-graphics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,12 +17,12 @@
         <!--required JavaFX dependencies -->
         <dependency>
             <groupId>org.openjfx</groupId>
-            <artifactId>javafx-graphics</artifactId>
+            <artifactId>javafx-controls</artifactId>
             <version>11</version>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
-            <artifactId>javafx-controls</artifactId>
+            <artifactId>javafx-web</artifactId>
             <version>11</version>
         </dependency>
         <dependency>
@@ -32,7 +32,7 @@
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
-            <artifactId>javafx-web</artifactId>
+            <artifactId>javafx-media</artifactId>
             <version>11</version>
         </dependency>
         <!--ArcGIS Runtime SDK jar dependency -->


### PR DESCRIPTION
1. Add `javafx-media`,  per Colin Anderson [here](https://devtopia.esri.com/runtime/common-doc/issues/1269#issuecomment-1597233).

1. Remove `javafx-graphics`